### PR TITLE
Pycryptodome update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scrypt
 pyyaml
 
 # for AES, installed through graphenelib already
-pycryptodome
+pycryptodome==3.8.0
 
 # for the CLI tool
 click


### PR DESCRIPTION
Limit the version pycryptodome update to 3.8.0 to match with graphenelib 1.1.17