### PR TITLE
Corrected help message for createwallet

### DIFF
--- a/peerplays/cli/wallet.py
+++ b/peerplays/cli/wallet.py
@@ -16,7 +16,7 @@ from .main import main
 )
 @offlineChain
 def createwallet(ctx, password):
-    """ Change the wallet passphrase
+    """ Create a wallet
     """
     ctx.peerplays.wallet.create(password)
 


### PR DESCRIPTION
This fixes issue #30 
Help message for createwallet changed to "Create a wallet"